### PR TITLE
Intellisense: doc comments and inbox (server) terminology

### DIFF
--- a/analysis.go
+++ b/analysis.go
@@ -1,5 +1,8 @@
 package mailosaur
 
+// AnalysisService provides operations for analyzing the content and deliverability of an
+// email, including SpamAssassin scoring and per-provider deliverability reports. Accessed via
+// the Analysis field of MailosaurClient.
 type AnalysisService struct {
 	client *MailosaurClient
 }
@@ -66,11 +69,16 @@ type DeliverabilityReport struct {
 	SpamAssassin *SpamAssassinResult          `json:"spamAssassin"`
 }
 
+// Spam performs a spam analysis of an email. The id argument is the identifier of the
+// message to analyze, and it returns a SpamAnalysisResult containing the spam score and
+// filter results.
 func (s *AnalysisService) Spam(id string) (*SpamAnalysisResult, error) {
 	result, err := s.client.HttpGet(&SpamAnalysisResult{}, "api/analysis/spam/"+id)
 	return result.(*SpamAnalysisResult), err
 }
 
+// Deliverability performs a deliverability report of an email. The id argument is the
+// identifier of the message to analyze, and it returns a DeliverabilityReport for the email.
 func (s *AnalysisService) Deliverability(id string) (*DeliverabilityReport, error) {
 	result, err := s.client.HttpGet(&DeliverabilityReport{}, "api/analysis/deliverability/"+id)
 	return result.(*DeliverabilityReport), err

--- a/client.go
+++ b/client.go
@@ -21,7 +21,7 @@ type MailosaurClient struct {
 	userAgent  string
 	httpClient *http.Client
 
-	// Servers provides operations for creating and managing your Mailosaur servers (virtual inboxes).
+	// Servers provides operations for creating and managing your Mailosaur inboxes (servers).
 	Servers *ServersService
 	// Messages provides operations for finding, retrieving, creating, and managing email and SMS messages.
 	Messages *MessagesService

--- a/client.go
+++ b/client.go
@@ -11,18 +11,29 @@ import (
 	"time"
 )
 
+// MailosaurClient is the main entry point to the Mailosaur API. Construct an instance with
+// your API key (or set the MAILOSAUR_API_KEY environment variable) via New, then use the
+// operation service fields (Messages, Servers, Files, Devices, Analysis, Previews, Usage) to
+// automate email and SMS testing.
 type MailosaurClient struct {
 	baseUrl    string
 	apiKey     string
 	userAgent  string
 	httpClient *http.Client
 
-	Servers  *ServersService
+	// Servers provides operations for creating and managing your Mailosaur servers (virtual inboxes).
+	Servers *ServersService
+	// Messages provides operations for finding, retrieving, creating, and managing email and SMS messages.
 	Messages *MessagesService
+	// Analysis provides operations for analyzing email content and deliverability, including spam scoring.
 	Analysis *AnalysisService
-	Files    *FilesService
-	Usage    *UsageService
-	Devices  *DevicesService
+	// Files provides operations for downloading attachments, EML source, and email preview screenshots.
+	Files *FilesService
+	// Usage provides operations for inspecting account usage limits and recent transactional usage.
+	Usage *UsageService
+	// Devices provides operations for managing virtual security devices and retrieving their one-time passwords.
+	Devices *DevicesService
+	// Previews provides operations for discovering the email clients available for generating email previews.
 	Previews *PreviewsService
 }
 
@@ -50,6 +61,9 @@ func (e *mailosaurError) Error() string {
 	return e.Message
 }
 
+// New returns a new Mailosaur client. An API key may be passed as the optional argument;
+// if omitted or empty, the MAILOSAUR_API_KEY environment variable is used instead. The
+// client is configured with a default HTTP client with a one-minute timeout.
 func New(apiKey ...string) *MailosaurClient {
 	resolvedKey := ""
 	if len(apiKey) > 0 && len(apiKey[0]) > 0 {
@@ -60,6 +74,8 @@ func New(apiKey ...string) *MailosaurClient {
 	return NewWithClient(resolvedKey, &http.Client{Timeout: time.Minute})
 }
 
+// NewWithClient returns a new Mailosaur client that uses the supplied API key and HTTP
+// client, allowing the underlying transport, timeouts, and proxies to be customized.
 func NewWithClient(apiKey string, httpClient *http.Client) *MailosaurClient {
 	c := &MailosaurClient{
 		baseUrl:    "https://mailosaur.com/",

--- a/devices.go
+++ b/devices.go
@@ -5,6 +5,9 @@ import (
 	"time"
 )
 
+// DevicesService provides operations for managing virtual security devices and retrieving
+// their current one-time passwords (OTPs), used to automate testing of app-based
+// multi-factor authentication. Accessed via the Devices field of MailosaurClient.
 type DevicesService struct {
 	client *MailosaurClient
 }
@@ -28,16 +31,24 @@ type OtpResult struct {
 	Expires time.Time `json:"expires"`
 }
 
+// List returns a list of your virtual security devices. It returns a DeviceListResult
+// containing your devices.
 func (s *DevicesService) List() (*DeviceListResult, error) {
 	result, err := s.client.HttpGet(&DeviceListResult{}, "api/devices")
 	return result.(*DeviceListResult), err
 }
 
+// Create creates a new virtual security device. The deviceCreateOptions argument specifies
+// the options used to create the device. It returns the newly-created Device.
 func (s *DevicesService) Create(deviceCreateOptions DeviceCreateOptions) (*Device, error) {
 	result, err := s.client.HttpPost(&Device{}, "api/devices", deviceCreateOptions)
 	return result.(*Device), err
 }
 
+// Otp retrieves the current one-time password for a saved device, or for a given
+// base32-encoded shared secret. The query argument is either the unique identifier of the
+// device or a base32-encoded shared secret. It returns an OtpResult containing the current
+// one-time password.
 func (s *DevicesService) Otp(query string) (*OtpResult, error) {
 	if strings.Contains(query, "-") {
 		result, err := s.client.HttpGet(&OtpResult{}, "api/devices/"+query+"/otp")
@@ -48,6 +59,8 @@ func (s *DevicesService) Otp(query string) (*OtpResult, error) {
 	return result.(*OtpResult), err
 }
 
+// Delete permanently deletes a virtual security device. This operation cannot be undone. The
+// id argument is the unique identifier of the device to delete.
 func (s *DevicesService) Delete(id string) error {
 	return s.client.HttpDelete("api/devices/" + id)
 }

--- a/files.go
+++ b/files.go
@@ -6,20 +6,32 @@ import (
 	"time"
 )
 
+// FilesService provides operations for downloading the raw content associated with a
+// message — file attachments, the full EML source of an email, and rendered email previews.
+// Accessed via the Files field of MailosaurClient.
 type FilesService struct {
 	client *MailosaurClient
 }
 
+// GetAttachment downloads a single attachment. The id argument is the identifier of the
+// required attachment, and it returns a byte slice containing the attachment's binary content.
 func (s *FilesService) GetAttachment(id string) ([]byte, error) {
 	result, err := s.client.HttpGet(nil, "api/files/attachments/"+id)
 	return result.([]byte), err
 }
 
+// GetEmail downloads an EML file representing the specified email. The id argument is the
+// identifier of the required message, and it returns a byte slice containing the raw EML
+// content of the email.
 func (s *FilesService) GetEmail(id string) ([]byte, error) {
 	result, err := s.client.HttpGet(nil, "api/files/email/"+id)
 	return result.([]byte), err
 }
 
+// GetPreview downloads a screenshot of your email rendered in a real email client. The id
+// argument is the identifier of the required preview, and it returns a byte slice containing
+// the preview screenshot image. It returns a mailosaurError with error type preview_timeout
+// if the preview is not generated within the time limit.
 func (s *FilesService) GetPreview(id string) ([]byte, error) {
 	timeout := 120
 	pollCount := 0

--- a/messages.go
+++ b/messages.go
@@ -8,6 +8,9 @@ import (
 	"time"
 )
 
+// MessagesService provides operations for finding, retrieving, creating, forwarding,
+// replying to, and deleting the email and SMS messages received by your Mailosaur servers.
+// Accessed via the Messages field of MailosaurClient.
 type MessagesService struct {
 	client *MailosaurClient
 }
@@ -160,6 +163,10 @@ type PreviewRequestOptions struct {
 	EmailClients []string `json:"emailClients"`
 }
 
+// List returns a list of your messages in summary form, sorted by received date with the
+// most recently-received messages appearing first. The params argument specifies the server
+// to list messages from along with paging and filtering options. It returns a
+// MessageListResult containing the message summaries.
 func (s *MessagesService) List(params *MessageListParams) (*MessageListResult, error) {
 	u := buildPagePath(
 		"api/messages?server="+params.Server,
@@ -173,6 +180,12 @@ func (s *MessagesService) List(params *MessageListParams) (*MessageListResult, e
 	return result.(*MessageListResult), err
 }
 
+// Get waits for a message to be found, returning as soon as a message matching the given
+// search criteria is found. This is the most efficient way to look up a message and is
+// recommended wherever possible. The params argument specifies the server to search and
+// related options, and criteria specifies what to match. It returns the first matching
+// Message. It returns a mailosaurError with error type no_messages_found if no matching
+// message exists, or search_timeout if no matching message arrives before the timeout elapses.
 func (s *MessagesService) Get(params *MessageSearchParams, criteria *SearchCriteria) (*Message, error) {
 	// Timeout defaulted to 10s, receivedAfter to 1h
 	if params.ReceivedAfter.IsZero() {
@@ -194,6 +207,12 @@ func (s *MessagesService) Get(params *MessageSearchParams, criteria *SearchCrite
 	return s.GetById(result.Items[0].Id)
 }
 
+// Search returns a list of messages matching the given search criteria, in summary form,
+// sorted by received date with the most recently-received messages appearing first. The
+// params argument specifies the server to search along with paging and timeout options, and
+// criteria specifies what to match. It returns a MessageListResult containing the matching
+// message summaries. It returns a mailosaurError with error type search_timeout if no
+// matching message is found before the timeout elapses, unless ErrorOnTimeout is set to false.
 func (s *MessagesService) Search(params *MessageSearchParams, criteria *SearchCriteria) (*MessageListResult, error) {
 	pollCount := 0
 	startTime := time.Now()
@@ -269,34 +288,57 @@ func (s *MessagesService) Search(params *MessageSearchParams, criteria *SearchCr
 	}
 }
 
+// GetById retrieves the detail for a single message. It must be used in conjunction with
+// either List or Search in order to obtain the unique identifier for the required message.
+// The id argument is the unique identifier of the message to retrieve, and it returns the
+// full Message.
 func (s *MessagesService) GetById(id string) (*Message, error) {
 	result, err := s.client.HttpGet(&Message{}, "api/messages/"+id)
 	return result.(*Message), err
 }
 
+// Delete permanently deletes a message, along with any attachments related to it. This
+// operation cannot be undone. The id argument is the identifier of the message to delete.
 func (s *MessagesService) Delete(id string) error {
 	return s.client.HttpDelete("api/messages/" + id)
 }
 
+// DeleteAll permanently deletes all messages within a server. This operation cannot be
+// undone. The server argument is the unique identifier of the server to clear.
 func (s *MessagesService) DeleteAll(server string) error {
 	return s.client.HttpDelete("api/messages?server=" + server)
 }
 
+// Create creates a new message that can be sent to a verified email address. This is useful
+// when you want an email to trigger a workflow in your product. The server argument is the
+// unique identifier of the server, and messageCreateOptions specifies the message to create.
+// It returns the newly-created Message.
 func (s *MessagesService) Create(server string, messageCreateOptions *MessageCreateOptions) (*Message, error) {
 	result, err := s.client.HttpPost(&Message{}, "api/messages?server="+server, messageCreateOptions)
 	return result.(*Message), err
 }
 
+// Forward forwards the specified message to a verified email address. This is useful for
+// simulating a user forwarding one of your email messages. The id argument is the unique
+// identifier of the message to forward, and messageForwardOptions specifies the forwarding
+// options. It returns the forwarded Message.
 func (s *MessagesService) Forward(id string, messageForwardOptions *MessageForwardOptions) (*Message, error) {
 	result, err := s.client.HttpPost(&Message{}, "api/messages/"+id+"/forward", messageForwardOptions)
 	return result.(*Message), err
 }
 
+// Reply sends a reply to the specified message. This is useful for simulating a user
+// replying to one of your email or SMS messages. The id argument is the unique identifier of
+// the message to reply to, and messageReplyOptions specifies the reply options. It returns
+// the reply Message.
 func (s *MessagesService) Reply(id string, messageReplyOptions *MessageReplyOptions) (*Message, error) {
 	result, err := s.client.HttpPost(&Message{}, "api/messages/"+id+"/reply", messageReplyOptions)
 	return result.(*Message), err
 }
 
+// GeneratePreviews generates screenshots of an email rendered in the specified email
+// clients. The id argument is the identifier of the email to preview, and options specifies
+// which email clients to use. It returns a PreviewListResult containing the generated previews.
 func (s *MessagesService) GeneratePreviews(id string, options *PreviewRequestOptions) (*PreviewListResult, error) {
 	result, err := s.client.HttpPost(&PreviewListResult{}, "api/messages/"+id+"/screenshots", options)
 	return result.(*PreviewListResult), err

--- a/messages.go
+++ b/messages.go
@@ -9,8 +9,8 @@ import (
 )
 
 // MessagesService provides operations for finding, retrieving, creating, forwarding,
-// replying to, and deleting the email and SMS messages received by your Mailosaur servers.
-// Accessed via the Messages field of MailosaurClient.
+// replying to, and deleting the email and SMS messages received by your Mailosaur inboxes
+// (servers). Accessed via the Messages field of MailosaurClient.
 type MessagesService struct {
 	client *MailosaurClient
 }
@@ -164,8 +164,8 @@ type PreviewRequestOptions struct {
 }
 
 // List returns a list of your messages in summary form, sorted by received date with the
-// most recently-received messages appearing first. The params argument specifies the server
-// to list messages from along with paging and filtering options. It returns a
+// most recently-received messages appearing first. The params argument specifies the inbox
+// (server) to list messages from along with paging and filtering options. It returns a
 // MessageListResult containing the message summaries.
 func (s *MessagesService) List(params *MessageListParams) (*MessageListResult, error) {
 	u := buildPagePath(
@@ -182,7 +182,7 @@ func (s *MessagesService) List(params *MessageListParams) (*MessageListResult, e
 
 // Get waits for a message to be found, returning as soon as a message matching the given
 // search criteria is found. This is the most efficient way to look up a message and is
-// recommended wherever possible. The params argument specifies the server to search and
+// recommended wherever possible. The params argument specifies the inbox (server) to search and
 // related options, and criteria specifies what to match. It returns the first matching
 // Message. It returns a mailosaurError with error type no_messages_found if no matching
 // message exists, or search_timeout if no matching message arrives before the timeout elapses.
@@ -209,7 +209,7 @@ func (s *MessagesService) Get(params *MessageSearchParams, criteria *SearchCrite
 
 // Search returns a list of messages matching the given search criteria, in summary form,
 // sorted by received date with the most recently-received messages appearing first. The
-// params argument specifies the server to search along with paging and timeout options, and
+// params argument specifies the inbox (server) to search along with paging and timeout options, and
 // criteria specifies what to match. It returns a MessageListResult containing the matching
 // message summaries. It returns a mailosaurError with error type search_timeout if no
 // matching message is found before the timeout elapses, unless ErrorOnTimeout is set to false.
@@ -303,15 +303,15 @@ func (s *MessagesService) Delete(id string) error {
 	return s.client.HttpDelete("api/messages/" + id)
 }
 
-// DeleteAll permanently deletes all messages within a server. This operation cannot be
-// undone. The server argument is the unique identifier of the server to clear.
+// DeleteAll permanently deletes all messages within an inbox (server). This operation cannot
+// be undone. The server argument is the unique identifier of the inbox (server) to clear.
 func (s *MessagesService) DeleteAll(server string) error {
 	return s.client.HttpDelete("api/messages?server=" + server)
 }
 
 // Create creates a new message that can be sent to a verified email address. This is useful
 // when you want an email to trigger a workflow in your product. The server argument is the
-// unique identifier of the server, and messageCreateOptions specifies the message to create.
+// unique identifier of the inbox (server), and messageCreateOptions specifies the message to create.
 // It returns the newly-created Message.
 func (s *MessagesService) Create(server string, messageCreateOptions *MessageCreateOptions) (*Message, error) {
 	result, err := s.client.HttpPost(&Message{}, "api/messages?server="+server, messageCreateOptions)

--- a/previews.go
+++ b/previews.go
@@ -1,5 +1,8 @@
 package mailosaur
 
+// PreviewsService provides operations for discovering the email clients available for
+// generating email previews (screenshots of an email rendered in real clients). Accessed via
+// the Previews field of MailosaurClient.
 type PreviewsService struct {
 	client *MailosaurClient
 }
@@ -13,6 +16,8 @@ type EmailClientListResult struct {
 	Items []*EmailClient `json:"items"`
 }
 
+// ListEmailClients lists all email clients that can be used to generate email previews. It
+// returns an EmailClientListResult of available email clients.
 func (s *PreviewsService) ListEmailClients() (*EmailClientListResult, error) {
 	result, err := s.client.HttpGet(&EmailClientListResult{}, "api/screenshots/clients")
 	return result.(*EmailClientListResult), err

--- a/servers.go
+++ b/servers.go
@@ -6,6 +6,9 @@ import (
 	"os"
 )
 
+// ServersService provides operations for creating and managing your Mailosaur servers — the
+// virtual inboxes that group your tests together, each with its own domain and
+// SMTP/POP3/IMAP credentials. Accessed via the Servers field of MailosaurClient.
 type ServersService struct {
 	client *MailosaurClient
 }
@@ -24,21 +27,30 @@ type ServerCreateOptions struct {
 	Name string `json:"name"`
 }
 
+// List returns a list of your virtual servers, sorted in alphabetical order. It returns a
+// ServerListResult containing your servers.
 func (s *ServersService) List() (*ServerListResult, error) {
 	result, err := s.client.HttpGet(&ServerListResult{}, "api/servers")
 	return result.(*ServerListResult), err
 }
 
+// Create creates a new virtual server. The serverCreateOptions argument specifies the
+// options used to create the server. It returns the newly-created Server.
 func (s *ServersService) Create(serverCreateOptions ServerCreateOptions) (*Server, error) {
 	result, err := s.client.HttpPost(&Server{}, "api/servers", serverCreateOptions)
 	return result.(*Server), err
 }
 
+// Get retrieves the detail for a single server. The id argument is the unique identifier of
+// the server, and it returns the Server.
 func (s *ServersService) Get(id string) (*Server, error) {
 	result, err := s.client.HttpGet(&Server{}, "api/servers/"+id)
 	return result.(*Server), err
 }
 
+// GetPassword retrieves the password for a server, which can be used for SMTP, POP3, and
+// IMAP connectivity. The id argument is the unique identifier of the server, and it returns
+// the server's password.
 func (s *ServersService) GetPassword(id string) (string, error) {
 	type Result struct {
 		Value string `json:"value"`
@@ -50,15 +62,23 @@ func (s *ServersService) GetPassword(id string) (string, error) {
 	return parsed.Value, err
 }
 
+// Update updates the attributes of a server. The id argument is the unique identifier of the
+// server, and server is the updated server. It returns the updated Server.
 func (s *ServersService) Update(id string, server *Server) (*Server, error) {
 	result, err := s.client.HttpPut(&Server{}, "api/servers/"+id, server)
 	return result.(*Server), err
 }
 
+// Delete permanently deletes a server, along with all messages and associated attachments
+// within it. This operation cannot be undone. The id argument is the unique identifier of
+// the server to delete.
 func (s *ServersService) Delete(id string) error {
 	return s.client.HttpDelete("api/servers/" + id)
 }
 
+// GenerateEmailAddress generates a random email address by prefixing a random string to the
+// server's domain name. The id argument is the identifier of the server, and it returns a
+// random email address ending in the server's domain.
 func (s *ServersService) GenerateEmailAddress(id string) string {
 	host := os.Getenv("MAILOSAUR_SMTP_HOST")
 	if len(host) == 0 {

--- a/servers.go
+++ b/servers.go
@@ -6,8 +6,8 @@ import (
 	"os"
 )
 
-// ServersService provides operations for creating and managing your Mailosaur servers — the
-// virtual inboxes that group your tests together, each with its own domain and
+// ServersService provides operations for creating and managing your Mailosaur inboxes
+// (servers) — they group your tests together, each with its own domain and
 // SMTP/POP3/IMAP credentials. Accessed via the Servers field of MailosaurClient.
 type ServersService struct {
 	client *MailosaurClient
@@ -27,30 +27,30 @@ type ServerCreateOptions struct {
 	Name string `json:"name"`
 }
 
-// List returns a list of your virtual servers, sorted in alphabetical order. It returns a
-// ServerListResult containing your servers.
+// List returns a list of your inboxes (servers), sorted in alphabetical order. It returns a
+// ServerListResult containing your inboxes (servers).
 func (s *ServersService) List() (*ServerListResult, error) {
 	result, err := s.client.HttpGet(&ServerListResult{}, "api/servers")
 	return result.(*ServerListResult), err
 }
 
-// Create creates a new virtual server. The serverCreateOptions argument specifies the
-// options used to create the server. It returns the newly-created Server.
+// Create creates a new inbox (server). The serverCreateOptions argument specifies the
+// options used to create the inbox (server). It returns the newly-created Server.
 func (s *ServersService) Create(serverCreateOptions ServerCreateOptions) (*Server, error) {
 	result, err := s.client.HttpPost(&Server{}, "api/servers", serverCreateOptions)
 	return result.(*Server), err
 }
 
-// Get retrieves the detail for a single server. The id argument is the unique identifier of
-// the server, and it returns the Server.
+// Get retrieves the detail for a single inbox (server). The id argument is the unique
+// identifier of the inbox (server), and it returns the Server.
 func (s *ServersService) Get(id string) (*Server, error) {
 	result, err := s.client.HttpGet(&Server{}, "api/servers/"+id)
 	return result.(*Server), err
 }
 
-// GetPassword retrieves the password for a server, which can be used for SMTP, POP3, and
-// IMAP connectivity. The id argument is the unique identifier of the server, and it returns
-// the server's password.
+// GetPassword retrieves the password for an inbox (server), which can be used for SMTP,
+// POP3, and IMAP connectivity. The id argument is the unique identifier of the inbox
+// (server), and it returns the password for the inbox (server).
 func (s *ServersService) GetPassword(id string) (string, error) {
 	type Result struct {
 		Value string `json:"value"`
@@ -62,23 +62,25 @@ func (s *ServersService) GetPassword(id string) (string, error) {
 	return parsed.Value, err
 }
 
-// Update updates the attributes of a server. The id argument is the unique identifier of the
-// server, and server is the updated server. It returns the updated Server.
+// Update updates the attributes of an inbox (server). The id argument is the unique
+// identifier of the inbox (server), and server is the updated inbox (server). It returns the
+// updated Server.
 func (s *ServersService) Update(id string, server *Server) (*Server, error) {
 	result, err := s.client.HttpPut(&Server{}, "api/servers/"+id, server)
 	return result.(*Server), err
 }
 
-// Delete permanently deletes a server, along with all messages and associated attachments
-// within it. This operation cannot be undone. The id argument is the unique identifier of
-// the server to delete.
+// Delete permanently deletes an inbox (server), along with all messages and associated
+// attachments within it. This operation cannot be undone. The id argument is the unique
+// identifier of the inbox (server) to delete.
 func (s *ServersService) Delete(id string) error {
 	return s.client.HttpDelete("api/servers/" + id)
 }
 
 // GenerateEmailAddress generates a random email address by prefixing a random string to the
-// server's domain name. The id argument is the identifier of the server, and it returns a
-// random email address ending in the server's domain.
+// domain name of the inbox (server). The id argument is the identifier of the inbox
+// (server), and it returns a random email address ending in the domain of the inbox
+// (server).
 func (s *ServersService) GenerateEmailAddress(id string) string {
 	host := os.Getenv("MAILOSAUR_SMTP_HOST")
 	if len(host) == 0 {

--- a/usage.go
+++ b/usage.go
@@ -4,6 +4,9 @@ import (
 	"time"
 )
 
+// UsageService provides operations for inspecting your account's usage limits and recent
+// transactional usage. These endpoints require authentication with an account-level API key.
+// Accessed via the Usage field of MailosaurClient.
 type UsageService struct {
 	client *MailosaurClient
 }
@@ -30,11 +33,17 @@ type UsageTransactionListResult struct {
 	Items []*UsageTransaction `json:"items"`
 }
 
+// Limits retrieves account usage limits, detailing the current limits and usage for your
+// account. This endpoint requires authentication with an account-level API key. It returns
+// the UsageAccountLimits for your account.
 func (s *UsageService) Limits() (*UsageAccountLimits, error) {
 	result, err := s.client.HttpGet(&UsageAccountLimits{}, "api/usage/limits")
 	return result.(*UsageAccountLimits), err
 }
 
+// Transactions retrieves the last 31 days of transactional usage. This endpoint requires
+// authentication with an account-level API key. It returns a UsageTransactionListResult for
+// the last 31 days.
 func (s *UsageService) Transactions() (*UsageTransactionListResult, error) {
 	result, err := s.client.HttpGet(&UsageTransactionListResult{}, "api/usage/transactions")
 	return result.(*UsageTransactionListResult), err


### PR DESCRIPTION
## Summary

- Add and expand Intellisense doc comments across the client and operations classes (descriptions, parameters, and return values).
- Adopt **inbox (server)** terminology in the doc-comment prose, so hover documentation matches the dashboard UI.

## Scope

- Doc comments only — no code, public API, or behaviour changes.
- Parameter names, type names, and other code identifiers are unchanged.
